### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/20140214-19351392424556-I10.algorithms.hashing.md
+++ b/20140214-19351392424556-I10.algorithms.hashing.md
@@ -952,7 +952,7 @@ more precise citations. *(November 2009)*
     [doi](/wiki/Digital_object_identifier "Digital object identifier"):[10.1145/1811099.1811056](http://dx.doi.org/10.1145%2F1811099.1811056)
 -   Kirsch, Adam; Mitzenmacher, Michael (2006), ["Less Hashing, Same
     Performance: Building a Better Bloom
-    Filter"](http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf),
+    Filter"](https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf),
     in Azar, Yossi; Erlebach, Thomas, *Algorithms – ESA 2006, 14th
     Annual European Symposium*, Lecture Notes in Computer Science
     **4168**, Springer-Verlag, Lecture Notes in Computer Science 4168,


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author